### PR TITLE
Option to invert the function of the shift-key

### DIFF
--- a/scripts/index.js
+++ b/scripts/index.js
@@ -3,10 +3,16 @@ class TIsForTarget {
   static onKeyDown(e) {
       if (e.which == 84) {
         if (TIsForTarget.hovering) {
+          let releaseOthers = !e.shiftKey;
+
+          if (game.settings.get("t-is-for-target", "invertshift")) {
+            releaseOthers = !releaseOthers;
+          }
+
           if (game.user.targets.has(TIsForTarget.hovering))
-            TIsForTarget.hovering.setTarget(false, {user: game.user, releaseOthers: !e.shiftKey});
+            TIsForTarget.hovering.setTarget(false, {user: game.user, releaseOthers: releaseOthers});
           else
-            TIsForTarget.hovering.setTarget(game.user, {releaseOthers: !e.shiftKey});
+            TIsForTarget.hovering.setTarget(game.user, {releaseOthers: releaseOthers});
         }
       }
   }
@@ -25,3 +31,13 @@ class TIsForTarget {
 Hooks.on('canvasReady',TIsForTarget.ready);
 Hooks.on('hoverToken', TIsForTarget.onHoverToken);
 
+Hooks.once("init", () => {
+    game.settings.register("t-is-for-target", "invertshift", {
+      name: "Invert multitarget behavior",
+      hint: "Inverts the behavior of the shift key. If this is active and shift is pressed, previous target are released, otherwise an additional target is assigned. ",
+      scope: "world",
+      config: true,
+      default: false,
+      type: Boolean
+  });
+});


### PR DESCRIPTION
Added an option that inverts the function of the Shift-Key.
With this setting enabled, if shift is pressed, old targets are released. Otherwise the current hover is targeted additionally.

I like the functionality better that way.

Solves: https://github.com/basicer/foundryvtt-t-is-for-target/issues/2